### PR TITLE
Fallback to title and year search if IMDB ID lookup fails

### DIFF
--- a/notify.py
+++ b/notify.py
@@ -225,11 +225,16 @@ def main():
 
     # Fetch movie information
     if args.meta_imdb:
-        # Use IMDB ID to find TMDB ID
+        # Use IMDB ID to find TMDB ID, fallback to title+year if not found
         movie_result = movie_client.find_movie_by_imdb_id(args.meta_imdb)
-        if not movie_result:
-            raise ValueError(f"No movie found with IMDB ID: {args.meta_imdb}")
-        tmdb_id = movie_result['id']
+        if movie_result:
+            tmdb_id = movie_result['id']
+        else:
+            print(f"IMDB ID {args.meta_imdb} not found, falling back to title and year search")
+            results = movie_client.search_movie(args.parsed_title, args.release_year)
+            if not results:
+                raise ValueError(f"No movie found with IMDB ID: {args.meta_imdb} or title/year: {args.parsed_title} ({args.release_year})")
+            tmdb_id = results[0].id
     else:
         # Use title and year search
         results = movie_client.search_movie(args.parsed_title, args.release_year)


### PR DESCRIPTION
## Summary
- Enhances movie metadata fetching by adding a fallback mechanism
- If IMDB ID lookup fails, the system now searches by movie title and release year
- Improves robustness and user experience when IMDB ID is not found

## Changes

### Metadata Fetching Logic
- Modified the IMDB ID lookup to:
  - Attempt to find the TMDB ID using the IMDB ID first
  - If no result is found, fallback to searching by parsed movie title and release year
  - Raise an error only if both methods fail to find a movie
- Added informative print statement when falling back to title/year search

## Test plan
- [x] Verify that movies are correctly found using IMDB ID
- [x] Test fallback search by title and year when IMDB ID is invalid or missing
- [x] Confirm appropriate error is raised if no movie is found by either method
- [x] Check that fallback message is printed to console when triggered

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9254e3e5-d96c-412f-ab6a-c31e9005dfa8